### PR TITLE
Add node atrr is_executed

### DIFF
--- a/stn/node.py
+++ b/stn/node.py
@@ -4,35 +4,41 @@ from stn.utils.uuid import from_str
 class Node(object):
     """Represents a timepoint in the STN """
 
-    def __init__(self, task_id, node_type):
+    def __init__(self, task_id, node_type, is_executed=False):
         # id of the task represented by this node
         if isinstance(task_id, str):
             task_id = from_str(task_id)
         self.task_id = task_id
         # The node can be of node_type zero_timepoint, start, pickup or delivery
         self.node_type = node_type
+        self.is_executed = is_executed
 
     def __str__(self):
         to_print = ""
-        to_print += "node {} {}".format(self.task_id, self.node_type)
+        to_print += "{} {}".format(self.task_id, self.node_type)
         return to_print
 
     def __repr__(self):
         return str(self.to_dict())
 
     def __hash__(self):
-        return hash((self.task_id, self.node_type))
+        return hash((self.task_id, self.node_type, self.is_executed))
 
     def __eq__(self, other):
         if other is None:
             return False
         return (self.task_id == other.task_id and
-                self.node_type == other.node_type)
+                self.node_type == other.node_type and
+                self.is_executed == other.is_executed)
+
+    def execute(self):
+        self.is_executed = True
 
     def to_dict(self):
         node_dict = dict()
         node_dict['task_id'] = str(self.task_id)
         node_dict['node_type'] = self.node_type
+        node_dict['is_executed'] = self.is_executed
         return node_dict
 
     @staticmethod
@@ -41,5 +47,6 @@ class Node(object):
         if isinstance(task_id, str):
             task_id = from_str(task_id)
         node_type = node_dict['node_type']
-        node = Node(task_id, node_type)
+        is_executed = node_dict.get('is_executed', False)
+        node = Node(task_id, node_type, is_executed)
         return node

--- a/stn/pstn/pstn.py
+++ b/stn/pstn/pstn.py
@@ -53,13 +53,19 @@ class PSTN(STN):
                     lower_bound = -self[j][i]['weight']
                     upper_bound = self[i][j]['weight']
                     to_print += "Timepoint {}: [{}, {}]".format(timepoint, lower_bound, upper_bound)
+                    if timepoint.is_executed:
+                        to_print += " Ex"
                 # Constraints between the other timepoints
                 else:
                     if 'is_contingent' in self[j][i]:
                         to_print += "Constraint {} => {}: [{}, {}] ({})".format(i, j, -self[j][i]['weight'], self[i][j]['weight'], self[i][j]['distribution'])
+                        if self[i][j]['is_executed']:
+                            to_print += " Ex"
                     else:
 
                         to_print += "Constraint {} => {}: [{}, {}]".format(i, j, -self[j][i]['weight'], self[i][j]['weight'])
+                        if self[i][j]['is_executed']:
+                            to_print += " Ex"
 
                 to_print += "\n"
 
@@ -90,11 +96,8 @@ class PSTN(STN):
 
         super().add_constraint(i, j, wji, wij)
 
-        self.add_edge(i, j, distribution=distribution)
-        self.add_edge(i, j, is_contingent=is_contingent)
-
-        self.add_edge(j, i, distribution=distribution)
-        self.add_edge(j, i, is_contingent=is_contingent)
+        self.add_edge(i, j, distribution=distribution, is_contingent=is_contingent)
+        self.add_edge(j, i, distribution=distribution, is_contingent=is_contingent)
 
     def get_contingent_constraints(self):
         """ Returns a dictionary with the contingent constraints in the PSTN

--- a/stn/stn.py
+++ b/stn/stn.py
@@ -320,7 +320,7 @@ class STN(nx.DiGraph):
             for n in nodes:
                 self.update_edge_weight(column, n, shortest_path_array[column][n])
 
-    def update_edge_weight(self, i, j, weight, create=False):
+    def update_edge_weight(self, i, j, weight, force=False):
         """ Updates the weight of the edge between node starting_node and node ending_node
 
         Updates the weight if the new weight is less than the previous weight
@@ -340,7 +340,10 @@ class STN(nx.DiGraph):
             if weight < self[i][j]['weight']:
                 self[i][j]['weight'] = weight
 
-    def assign_timepoint(self, allotted_time, task_id, node_type):
+            if force:
+                self[i][j]['weight'] = weight
+
+    def assign_timepoint(self, allotted_time, task_id, node_type, force=False):
         """
         Assigns the allotted time to the earliest and latest time of the timepoint
         of task_id of type node_type
@@ -353,8 +356,8 @@ class STN(nx.DiGraph):
         for i in self.nodes():
             node_data = self.nodes[i]['data']
             if node_data.task_id == task_id and node_data.node_type == node_type:
-                self.update_edge_weight(0, i, allotted_time)
-                self.update_edge_weight(i, 0, -allotted_time)
+                self.update_edge_weight(0, i, allotted_time, force)
+                self.update_edge_weight(i, 0, -allotted_time, force)
                 break
 
     def get_edge_weight(self, i, j):
@@ -455,10 +458,16 @@ class STN(nx.DiGraph):
         Returns: (string) task id
 
         """
-        start_node = 2 * position + (position-2)
+        start_node_id = 2 * position + (position-2)
+        pickup_node_id = start_node_id + 1
+        delivery_node_id = pickup_node_id + 1
 
-        if self.has_node(start_node):
-            task_id = self.nodes[start_node]['data'].task_id
+        if self.has_node(start_node_id):
+            task_id = self.nodes[start_node_id]['data'].task_id
+        elif self.has_node(pickup_node_id):
+            task_id = self.nodes[pickup_node_id]['data'].task_id
+        elif self.has_node(delivery_node_id):
+            task_id = self.nodes[delivery_node_id]['data'].task_id
         else:
             self.logger.error("There is no task in position %s", position)
             return

--- a/stn/stnu/stnu.py
+++ b/stn/stnu/stnu.py
@@ -27,13 +27,19 @@ class STNU(STN):
                     lower_bound = -self[j][i]['weight']
                     upper_bound = self[i][j]['weight']
                     to_print += "Timepoint {}: [{}, {}]".format(timepoint, lower_bound, upper_bound)
+                    if timepoint.is_executed:
+                        to_print += " Ex"
                 # Constraints between the other timepoints
                 else:
                     if self[j][i]['is_contingent'] is True:
                         to_print += "Constraint {} => {}: [{}, {}] (contingent)".format(i, j, -self[j][i]['weight'], self[i][j]['weight'])
+                        if self[i][j]['is_executed']:
+                            to_print += " Ex"
                     else:
 
                         to_print += "Constraint {} => {}: [{}, {}]".format(i, j, -self[j][i]['weight'], self[i][j]['weight'])
+                        if self[i][j]['is_executed']:
+                            to_print += " Ex"
 
                 to_print += "\n"
 
@@ -68,7 +74,6 @@ class STNU(STN):
         super().add_constraint(i, j, wji, wij)
 
         self.add_edge(i, j, is_contingent=is_contingent)
-
         self.add_edge(j, i, is_contingent=is_contingent)
 
     def get_contingent_constraints(self):

--- a/test/data/pstn_two_tasks.json
+++ b/test/data/pstn_two_tasks.json
@@ -5,154 +5,176 @@
          "target":1,
          "weight":Infinity,
          "source":0,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":2,
          "weight":47.0,
          "source":0,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":3,
          "weight":Infinity,
          "source":0,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":4,
          "weight":Infinity,
          "source":0,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":5,
          "weight":102.0,
          "source":0,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":6,
          "weight":Infinity,
          "source":0,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":0,
          "weight":-0.0,
          "source":1,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"N_6_1",
          "target":2,
          "weight":Infinity,
          "source":1,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":0,
          "weight":-41.0,
          "source":2,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"N_6_1",
          "target":1,
          "weight":-0.0,
          "source":2,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"N_4_1",
          "target":3,
          "weight":Infinity,
          "source":2,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":0,
          "weight":-0.0,
          "source":3,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"N_4_1",
          "target":2,
          "weight":-0.0,
          "source":3,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":4,
          "weight":Infinity,
          "source":3,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":0,
          "weight":-0.0,
          "source":4,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":3,
          "weight":-0.0,
          "source":4,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"N_6_1",
          "target":5,
          "weight":Infinity,
          "source":4,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":0,
          "weight":-96.0,
          "source":5,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"N_6_1",
          "target":4,
          "weight":-0.0,
          "source":5,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"N_4_1",
          "target":6,
          "weight":Infinity,
          "source":5,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       },
       {
          "distribution":"",
          "target":0,
          "weight":-0.0,
          "source":6,
-         "is_contingent":false
+         "is_contingent":false,
+         "is_executed": false
       },
       {
          "distribution":"N_4_1",
          "target":5,
          "weight":-0.0,
          "source":6,
-         "is_contingent":true
+         "is_contingent":true,
+         "is_executed": false
       }
    ],
    "graph":{

--- a/test/data/stn_two_tasks.json
+++ b/test/data/stn_two_tasks.json
@@ -3,112 +3,134 @@
       {
          "source":0,
          "target":1,
-         "weight":41.0
+         "weight":41.0,
+         "is_executed": false
       },
       {
          "source":0,
          "target":2,
-         "weight":47.0
+         "weight":47.0,
+         "is_executed": false
       },
       {
          "source":0,
          "target":3,
-         "weight":51.0
+         "weight":51.0,
+         "is_executed": false
       },
       {
          "source":0,
          "target":4,
-         "weight":96.0
+         "weight":96.0,
+         "is_executed": false
       },
       {
          "source":0,
          "target":5,
-         "weight":102.0
+         "weight":102.0,
+         "is_executed": false
       },
       {
          "source":0,
          "target":6,
-         "weight":106.0
+         "weight":106.0,
+         "is_executed": false
       },
       {
          "source":1,
          "target":0,
-         "weight":-35.0
+         "weight":-35.0,
+         "is_executed": false
       },
       {
          "source":1,
          "target":2,
-         "weight":Infinity
+         "weight":Infinity,
+         "is_executed": false
       },
       {
          "source":2,
          "target":0,
-         "weight":-41.0
+         "weight":-41.0,
+         "is_executed": false
       },
       {
          "source":2,
          "target":1,
-         "weight":-6.0
+         "weight":-6.0,
+         "is_executed": false
       },
       {
          "source":2,
          "target":3,
-         "weight":Infinity
+         "weight":Infinity,
+         "is_executed": false
       },
       {
          "source":3,
          "target":0,
-         "weight":-45.0
+         "weight":-45.0,
+         "is_executed": false
       },
       {
          "source":3,
          "target":2,
-         "weight":-4.0
+         "weight":-4.0,
+         "is_executed": false
       },
       {
          "source":3,
          "target":4,
-         "weight":Infinity
+         "weight":Infinity,
+         "is_executed": false
       },
       {
          "source":4,
          "target":0,
-         "weight":-90.0
+         "weight":-90.0,
+         "is_executed": false
       },
       {
          "source":4,
          "target":3,
-         "weight":-0.0
+         "weight":-0.0,
+         "is_executed": false
       },
       {
          "source":4,
          "target":5,
-         "weight":Infinity
+         "weight":Infinity,
+         "is_executed": false
       },
       {
          "source":5,
          "target":0,
-         "weight":-96.0
+         "weight":-96.0,
+         "is_executed": false
       },
       {
          "source":5,
          "target":4,
-         "weight":-6.0
+         "weight":-6.0,
+         "is_executed": false
       },
       {
          "source":5,
          "target":6,
-         "weight":Infinity
+         "weight":Infinity,
+         "is_executed": false
       },
       {
          "source":6,
          "target":0,
-         "weight":-100.0
+         "weight":-100.0,
+         "is_executed": false
       },
       {
          "source":6,
          "target":5,
-         "weight":-4.0
+         "weight":-4.0,
+         "is_executed": false
       }
    ],
    "graph":{

--- a/test/data/stnu_two_tasks.json
+++ b/test/data/stnu_two_tasks.json
@@ -63,133 +63,155 @@
          "target":1,
          "is_contingent":false,
          "weight":Infinity,
-         "source":0
+         "source":0,
+         "is_executed": false
       },
       {
          "target":2,
          "is_contingent":false,
          "weight":47.0,
-         "source":0
+         "source":0,
+         "is_executed": false
       },
       {
          "target":3,
          "is_contingent":false,
          "weight":Infinity,
-         "source":0
+         "source":0,
+         "is_executed": false
       },
       {
          "target":4,
          "is_contingent":false,
          "weight":Infinity,
-         "source":0
+         "source":0,
+         "is_executed": false
       },
       {
          "target":5,
          "is_contingent":false,
          "weight":102.0,
-         "source":0
+         "source":0,
+         "is_executed": false
       },
       {
          "target":6,
          "is_contingent":false,
          "weight":Infinity,
-         "source":0
+         "source":0,
+         "is_executed": false
       },
       {
          "target":0,
          "is_contingent":false,
          "weight":-0.0,
-         "source":1
+         "source":1,
+         "is_executed": false
       },
       {
          "target":2,
          "is_contingent":true,
          "weight":8.0,
-         "source":1
+         "source":1,
+         "is_executed": false
       },
       {
          "target":0,
          "is_contingent":false,
          "weight":-41.0,
-         "source":2
+         "source":2,
+         "is_executed": false
       },
       {
          "target":1,
          "is_contingent":true,
          "weight":-4.0,
-         "source":2
+         "source":2,
+         "is_executed": false
       },
       {
          "target":3,
          "is_contingent":true,
          "weight":6.0,
-         "source":2
+         "source":2,
+         "is_executed": false
       },
       {
          "target":0,
          "is_contingent":false,
          "weight":-0.0,
-         "source":3
+         "source":3,
+         "is_executed": false
       },
       {
          "target":2,
          "is_contingent":true,
          "weight":-2.0,
-         "source":3
+         "source":3,
+         "is_executed": false
       },
       {
          "target":4,
          "is_contingent":false,
          "weight":Infinity,
-         "source":3
+         "source":3,
+         "is_executed": false
       },
       {
          "target":0,
          "is_contingent":false,
          "weight":-0.0,
-         "source":4
+         "source":4,
+         "is_executed": false
       },
       {
          "target":3,
          "is_contingent":false,
          "weight":0,
-         "source":4
+         "source":4,
+         "is_executed": false
       },
       {
          "target":5,
          "is_contingent":true,
          "weight":8.0,
-         "source":4
+         "source":4,
+         "is_executed": false
       },
       {
          "target":0,
          "is_contingent":false,
          "weight":-96.0,
-         "source":5
+         "source":5,
+         "is_executed": false
       },
       {
          "target":4,
          "is_contingent":true,
          "weight":-4.0,
-         "source":5
+         "source":5,
+         "is_executed": false
       },
       {
          "target":6,
          "is_contingent":true,
          "weight":6.0,
-         "source":5
+         "source":5,
+         "is_executed": false
       },
       {
          "target":0,
          "is_contingent":false,
          "weight":-0.0,
-         "source":6
+         "source":6,
+         "is_executed": false
       },
       {
          "target":5,
          "is_contingent":true,
          "weight":-2.0,
-         "source":6
+         "source":6,
+         "is_executed": false
       }
    ],
    "graph":{


### PR DESCRIPTION
- Add methods to mark a timepoint and an edge as executed
- Add method to remove executed timepoints which do not have an influence on the remaning timepoints
- Add method to get node_idx
- Add method to remove consecutive node_ids from idx 1 onwards
- Add argument force to assign_timepoint
- get_task_id(position): If a task does not have start node, return the pickup or the delivery node